### PR TITLE
Add create_app_engine_app variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,14 @@ variable "location" {
   type        = string
   description = "location for App Engine"
 }
+
+# TODO re-evaluate backup strategy
+variable "create_app_engine_app" {
+  type        = bool
+  description = <<EOT
+  Create project App Engine application. 
+  There can only be 1 per project, set this to false on 2nd+ uses.
+  Defaults to true for backward compatibility.
+  EOT
+  default     = true
+}


### PR DESCRIPTION
Create toggle to avoid re-creating an app engine app on projects where this module has been used before and projects where an app engine app already exists