### PR TITLE
Nesting of the module creates panic from unknowns.  Let's simplify

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,22 +13,24 @@ module "scheduler_service_account" {
   source     = "github.com/dapperlabs-platform/terraform-google-iam-service-account?ref=v1.1.8"
   project_id = var.project_name
   name       = "${var.instance_name}-scheduler"
-  iam_project_roles = {
-    "${var.project_name}" = [
-      "roles/workflows.invoker"
-    ]
-  }
+}
+
+resource "google_project_iam_member" "scheduler_workflow_invoker" {
+  project = var.project_name
+  role    = "roles/workflows.invoker"
+  member  = module.scheduler_service_account.email
 }
 
 module "workflow_service_account" {
   source     = "github.com/dapperlabs-platform/terraform-google-iam-service-account?ref=v1.1.8"
   project_id = var.project_name
   name       = "${var.instance_name}-workflow"
-  iam_project_roles = {
-    "${var.project_name}" = [
-      "roles/spanner.backupAdmin"
-    ]
-  }
+}
+
+resource "google_project_iam_member" "workflow_spanner_backup_admin" {
+  project = var.project_name
+  role    = "roles/spanner.backupAdmin"
+  member  = module.workflow_service_account.email
 }
 
 module "workflow" {

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "scheduler_service_account" {
 resource "google_project_iam_member" "scheduler_workflow_invoker" {
   project = var.project_name
   role    = "roles/workflows.invoker"
-  member  = module.scheduler_service_account.email
+  member  = module.scheduler_service_account.iam_email
 }
 
 module "workflow_service_account" {
@@ -30,7 +30,7 @@ module "workflow_service_account" {
 resource "google_project_iam_member" "workflow_spanner_backup_admin" {
   project = var.project_name
   role    = "roles/spanner.backupAdmin"
-  member  = module.workflow_service_account.email
+  member  = module.workflow_service_account.iam_email
 }
 
 module "workflow" {


### PR DESCRIPTION
Essentially this:

│ The "for_each" map includes keys derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.